### PR TITLE
Stop scrolling input from affecting quantity in merchandise list

### DIFF
--- a/Scripts/Game/UI/Menu/ShopSystem/ADM_ShopUI.c
+++ b/Scripts/Game/UI/Menu/ShopSystem/ADM_ShopUI.c
@@ -1,9 +1,9 @@
 class ADM_ShopUI_Item : SCR_ModularButtonComponent
 {
-	[Attribute(defvalue: "MenuNavLeft")]
+	[Attribute(defvalue: "MenuNavLeft_NoScroll")]
 	protected string m_sQuantityActionLess;
 	
-	[Attribute(defvalue: "MenuNavRight")]
+	[Attribute(defvalue: "MenuNavRight_NoScroll")]
 	protected string m_sQuantityActionMore;
 	
 	[Attribute(defvalue: "MenuLeft")]


### PR DESCRIPTION
Replace default values for `m_sQuantityActionLess` and m_sQuantityActionMore` with MenuNavLeft_NoScroll and MenuNavRight_NoScroll. With this change, the item quantity can only be affected by 'Z' and 'C' (or equivalent gamepad buttons) and not the scroll wheel.